### PR TITLE
multicast uses udp so make firewall documentation inclusive of this

### DIFF
--- a/galeracluster/source/firewallsettings.rst
+++ b/galeracluster/source/firewallsettings.rst
@@ -13,7 +13,7 @@
 By default, Galera Cluster may require all or some of the following ports to be open between the nodes: 
 
 - ``3306`` For MySQL client connections and State Snapshot Transfers through ``mysqldump``.
-- ``4567`` For Galera Cluster replication traffic.
+- ``4567`` For Galera Cluster replication traffic. Multicast uses UDP.
 - ``4568`` For Incremental State Transfers.
 - ``4444`` For all State Snapshot Transfers besides ``mysqldump``.
 
@@ -29,6 +29,13 @@ For example, in a :abbr:`LAN (Local Area Network)` environment the ``iptables`` 
     	--source 192.168.0.1/24 --dport 4568 -j ACCEPT
     $ iptables -A INPUT -i eth0 -p tcp -m tcp \
     	--source 192.168.0.1/24 --dport 4444 -j ACCEPT 
+
+When using multicast UDP is used. The following is also needed to allow multicast udp traffic:
+
+.. code-block:: console
+
+    $ iptables -A INPUT -i eth0 -p udp -m udp \
+    	--source 192.168.0.1/24 --dport 4567 -j ACCEPT
 
 In a :abbr:`WAN (Wide Area Network)` environment, this setup may be tedious to manage. Alternatively, with not much loss of security, you can simply open a full range of ports between trusted hosts:
 


### PR DESCRIPTION
i tested this out. tcpdump shows the traffic like

<pre>
13:22:59.339984 IP 10.1.2.110.4567 > 239.255.102.1.4567:  wb-dop: adsl-99-15-71-204.dsl.irvnca.sbcglobal.net:3025211876<2496703007:3081009675>
13:22:59.340315 IP 10.1.2.113.4567 > 239.255.102.1.4567:  wb-dop: static.kpn.net:2972717540<3120659454:1316642428>
13:22:59.340407 IP 10.1.2.119.4567 > 239.255.102.1.4567:  wb-dop: 185.66.36.96:2972455396<3188627084:1794942693>
13:22:59.340548 IP 10.1.2.111.4567 > 239.255.102.1.4567:  wb-dop: 142.62.163.91:3038384612<3140726717:3308151976>
13:22:59.340616 IP 10.1.2.110.4567 > 239.255.102.1.4567:  wb-dop: adsl-99-15-71-204.dsl.irvnca.sbcglobal.net:3025211876<2496703007:3081009675>
</pre>