### PR TITLE
wsrep_OSU_method is now a session variable

### DIFF
--- a/galeracluster/source/mysqlwsrepoptions.rst
+++ b/galeracluster/source/mysqlwsrepoptions.rst
@@ -78,7 +78,7 @@ These are MySQL system variables introduced by wsrep API patch v0.8. All variabl
 | <wsrep_on>` :sup:`S`                  |                                    |         |         |
 +---------------------------------------+------------------------------------+---------+---------+
 | :ref:`wsrep_OSU_method                | ``TOI``                            | 3+      |         |
-| <wsrep_OSU_method>`                   |                                    |         |         |
+| <wsrep_OSU_method>` :sup:`S`          |                                    |         |         |
 +---------------------------------------+------------------------------------+---------+---------+
 | :ref:`wsrep_preordered                | ``OFF``                            | 1+      |         |
 | <wsrep_preordered>`                   |                                    |         |         |
@@ -1044,9 +1044,9 @@ Defines the Online Schema Upgrade method the node uses to replicate :abbr:`DDL (
 +-------------------------+---------------------+-----------------------------------+
 | **System Variable**     | *Name:*             | ``wsrep_OSU_method``              |
 |                         +---------------------+-----------------------------------+
-|                         | *Variable Scope:*   | Global                            |
+|                         | *Variable Scope:*   | Global, Session                   |
 |                         +---------------------+-----------------------------------+
-|                         | *Dynamic Variable:* |                                   |
+|                         | *Dynamic Variable:* | Yes                               |
 +-------------------------+---------------------+-----------------------------------+
 | **Permitted Values**    | *Type:*             | enumeration                       |
 |                         +---------------------+-----------------------------------+


### PR DESCRIPTION
Prior towsrep 25.11, wsrep_OSU_method was only a global variable. Current behavior is now consistent with MySQL behavior for variables that have both global and session scope. This means if you want to change the variable in current session you need to do it with: SET wsrep_OSU_method (without the GLOBAL keyword). Setting the variable with SET GLOBAL wsrep_OSU_method will change the variable globally but it won’t have effect on current session.