### PR TITLE
Update weightedquorum.rst

### DIFF
--- a/galeracluster/source/weightedquorum.rst
+++ b/galeracluster/source/weightedquorum.rst
@@ -89,9 +89,9 @@ The quorum calculation formula is
 
 .. math::
    \frac{ \sum_{p_i \times w_i} - \sum_{l_i \times w_i}}
-   { 2} < \sum_{m_i \times w_i}
+   { 2} <= \sum_{m_i \times w_i}
    
-.. The original equation read (sum(p_i * w_i) - sum(l_i * w_i)) / 2 < sum(m_i * w_i).  Remove this comment after confirming that the LaTeX renders correctly.
+.. The original equation read (sum(p_i * w_i) - sum(l_i * w_i)) / 2 <= sum(m_i * w_i).  Remove this comment after confirming that the LaTeX renders correctly.
     
 Where:
 
@@ -103,7 +103,7 @@ Where:
 
 - :math:`w_i` Member weights.
 
-What this means is that the quorum is preserved if (and only if) the sum weight of the nodes in a new component strictly exceeds half that of the preceding :term:`Primary Component`, minus the nodes which left gracefully.
+What this means is that the quorum is preserved if (and only if) the sum weight of the nodes in a new component exceeds or is equal to half that of the preceding :term:`Primary Component`, minus the nodes which left gracefully.
 
 You can customize node weight using the :ref:`pc.weight <pc.weight>` parameter.  By default, node weight is ``1``, which translates to the traditional node count behavior.
 


### PR DESCRIPTION
after some testing it has been determined that the quorum is conserved if the sum weight of the node of a new compenent is equal to half taht of the precedeing primary component. either it's bug or the doc needs some update :)

setup : percona cluster 5.6 galera 3.16. node1 : weigth 2, node2 : weight 1, node3 : weight 1. kill -9 mysql on node1. node2 and 3 stays in primary component. old primary component weight = 4, gracefull exit weight  = 0, new primary component weight = 2.