### PR TITLE
Fix se linux policy gen

### DIFF
--- a/galeracluster/source/selinux.rst
+++ b/galeracluster/source/selinux.rst
@@ -91,7 +91,7 @@ To generate and load an SELinux policy for Galera Cluster, complete the followin
 
    .. code-block:: console
 
-      # fgrep "mysqld" /var/log/audit/audit.log | audit2allow -m MySQL_galera -o galera.te
+      # fgrep "mysqld" /var/log/audit/audit.log | audit2allow -m galera -o galera.te
 
    This creates a ``galera.te`` file in your working directory.
 

--- a/galeracluster/source/selinux.rst
+++ b/galeracluster/source/selinux.rst
@@ -121,7 +121,7 @@ To generate and load an SELinux policy for Galera Cluster, complete the followin
 
    .. code-block:: console
 
-      # semanage permissive -d mysql_t
+      # semanage permissive -d mysqld_t
 
 
 SELinux returns to enforcement mode, now using new policies that work with Galera Cluster.


### PR DESCRIPTION
When i followed the selinux policy configuration procedure in the [documentaion](http://galeracluster.com/documentation-webpages/selinux.html) i encountered an error:
```
# fgrep "mysqld" /var/log/audit/audit.log | audit2allow -m MySQL_galera -o galera.te
# checkmodule -M -m galera.te -o galera.mod
checkmodule: loading policy configuration from galera.te
checkmodule: module name Mysql_galera is different than the output base filename
```
The problem (according to what i found) is that the module name (MySQL_galera) is different than the output file name (galera.mod), so i changed the module name to 'galera' :
```
# fgrep "mysqld" /var/log/audit/audit.log | audit2allow -m galera -o galera.te
# checkmodule -M -m galera.te -o galera.mod
checkmodule: loading policy configuration from galera.te
checkmodule: policy configuration loaded
checkmodule: writing binary representation (version 17) to galera.mod
```
It is also possible to change the file name in the checkmodule command instead (to 'MySQL_galera.mod').

Also fixed a typo ('mysql' -> 'mysqld') in the final command (to return selinux enforcement on mysqld):
from - 
``` # semanage permissive -d mysql_t```
to - 
```# semanage permissive -d mysqld_t```