### PR TITLE
Added pin for galera repository

### DIFF
--- a/galeracluster/source/installmysql.rst
+++ b/galeracluster/source/installmysql.rst
@@ -59,6 +59,17 @@ Once you have the Software Properties installed, you can enable the Codership re
 
 	$ lsb_release -a
 
+#. Prefer the Codership repository over other sources. Using your preferred text editor, create a `galera.pref` file in the ``/etc/apt/preferences.d/`` directory.
+
+   .. code-block:: linux-config
+   
+      # Prefer Codership repository
+      Package: *
+      Pin: origin releases.galeracluster.com
+      Pin-Priority: 1001
+
+   This is needed to make sure the patched versions are preferred, for example if a 3rd-party program requires ``libmysqlclient20`` and the OS-Version for the library is newer. 
+
 #. Update the local cache.
 
    .. code-block:: console


### PR DESCRIPTION
Added pin to prefer galera repository over os repository even if os has newer versions.

This is the case for Ubuntu 16.04 LTS, the galeracluster.com repository contains 5.7.17~XXX, Ubuntu has 5.7.18-XXX. 