### PR TITLE
Fixed wrong URL for DEB-Repos

### DIFF
--- a/galeracluster/source/installmysql.rst
+++ b/galeracluster/source/installmysql.rst
@@ -45,8 +45,8 @@ Once you have the Software Properties installed, you can enable the Codership re
    .. code-block:: linux-config
 
       # Codership Repository (Galera Cluster for MySQL)
-      deb http://releases.codership.com/mysql-wsrep-VERSION/DIST RELEASE main
-      deb http://releases.codership.com/galera-3/DIST RELEASE main
+      deb http://releases.galeracluster.com/mysql-wsrep-VERSION/DIST RELEASE main
+      deb http://releases.galeracluster.com/galera-3/DIST RELEASE main
 
    For the repository address, make the following changes:
 


### PR DESCRIPTION
According to the announcement (http://galeracluster.com/2017/07/announcing-galera-cluster-5-7-18-5-6-36-and-5-5-55-with-galera-3-21-improvements-to-ipv6-support-bug-fixes-and-changes-to-repositories-structure/) the repos are hosted at releases.galeracluster.com not releases.codership.com