### PR TITLE
Fix typo in recovery documentation

### DIFF
--- a/galeracluster/source/recovery.rst
+++ b/galeracluster/source/recovery.rst
@@ -3,7 +3,7 @@
 ==================================
 .. _`node-failure-recovery`:
 
-Individual nodes fail to operate when they loose touch with the cluster.  This can occur due to various reasons.  For instance, in the event of hardware failure or software crash, the loss of network connectivity or the failure of a state transfer.  Anything that prevents the node from communicating with the cluster is generalized behind the concept of node failure.  Understanding how nodes fail will help in planning for their recovery.
+Individual nodes fail to operate when they lose touch with the cluster.  This can occur due to various reasons.  For instance, in the event of hardware failure or software crash, the loss of network connectivity or the failure of a state transfer.  Anything that prevents the node from communicating with the cluster is generalized behind the concept of node failure.  Understanding how nodes fail will help in planning for their recovery.
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The word 'lose' was spelled as 'loose'. This has been corrected.