### PR TITLE
Make Edit on Github great again

### DIFF
--- a/galeracluster/source/_templates/layout.html
+++ b/galeracluster/source/_templates/layout.html
@@ -201,7 +201,7 @@
 		<ul class="nav-link">
 			{% if sourcename %} 
 
-				<li><a href="https://github.com/codership/documentation/edit/draft/galeracluster/source/{{ sourcename [:-4] }}.rst" title="Edit '{{title}}' on Github">Edit on Github</a></li>
+				<li><a href="https://github.com/codership/documentation/edit/draft/galeracluster/source/{{ sourcename [:-4] }}" title="Edit '{{title}}' on Github">Edit on Github</a></li>
 
 			{% endif %} {{ super() }}
 


### PR DESCRIPTION
`sourcename` seems to already contains .rst extension.

I didn't find documentation on `[:-4]`, I suppose its a Jinja specific feature.