### PR TITLE
Release notes for Galera 3.29, MySQL-wsrep 5.6.47-25.29, 5.7.29-25.21.

### DIFF
--- a/galeracluster/source/documentation/galera-parameters.rst
+++ b/galeracluster/source/documentation/galera-parameters.rst
@@ -150,7 +150,9 @@ Below is a list of all of the Galera parameters.  Each is also a link to further
    ":ref:`repl.key_format <repl.key_format>`", "``FLAT8``", "  No", "", "3.0"
    ":ref:`repl.max_ws_size <repl.max_ws_size>`", "``2147483647``", "  No", "", "3.0"
    ":ref:`repl.proto_max <repl.proto_max>`", "``5``", "  No", "", "2.0"
-   ":ref:`socket.recv_buf_size <socket.recv_buf_size>`", "``212992``", "  Yes", "", "3.17"
+   ":ref:`socket.recv_buf_size <socket.recv_buf_size>`", "``auto``", "  Yes", "", "3.17"
+   ":ref:`socket.send_buf_size <socket.send_buf_size>`", "``auto``", "  Yes", "", "3.29"
+
    ":ref:`socket.ssl_ca <socket.ssl_ca>`", "", "  No", "", "1.0"
    ":ref:`socket.ssl_cert <socket.ssl_cert>`", "", "  No", "", "1.0"
    ":ref:`socket.checksum <socket.checksum>`", "``1`` (vs. 2); ``2`` (vs. 3)", "  No", "", "2.0"
@@ -1878,12 +1880,12 @@ The excerpt below is an example of how this Galera parameter might look in the c
 .. index::
    pair: wsrep Provider Options;  socket.recv_buf_size
 
-The size of the receive buffer that used on the network sockets between nodes. Galera passes the value to the kernel via the ``SO_RCVBUF`` socket option.
+The size of the receive buffer that used on the network sockets between nodes. Galera passes the value to the kernel via the ``SO_RCVBUF`` socket option. The value is either numeric value in bytes or ``auto`` which allows the kernel to autotune the receive buffer. The default was changed from ``212992`` to ``auto`` in 3.29.
 
 .. csv-table::
    :class: doc-options
 
-   "Default Value", "``212992``"
+   "Default Value", "``auto``"
    "Dynamic", "No"
    "Initial Version", "3.17"
 
@@ -1893,6 +1895,27 @@ The excerpt below is an example of how this Galera parameter might look in the c
 
    wsrep_provider_options="socket.recv_buf_size=212992"
 
+   .. _`socket.send_buf_size`:
+.. rst-class:: section-heading
+.. rubric:: ``socket.send_buf_size``
+
+.. index::
+   pair: wsrep Provider Options;  socket.send_buf_size
+
+The size of the send buffer that used on the network sockets between nodes. Galera passes the value to the kernel via the ``SO_SNDBUF`` socket option. The value is either numeric value in bytes or ``auto`` which allows the kernel to autotune the send buffer.
+
+.. csv-table::
+   :class: doc-options
+
+   "Default Value", "``auto``"
+   "Dynamic", "No"
+   "Initial Version", "3.29"
+
+The excerpt below is an example of how this Galera parameter might look in the configuration file:
+
+.. code-block:: ini
+
+   wsrep_provider_options="socket.send_buf_size=212992"
 
 .. _`socket.ssl_ca`:
 .. rst-class:: section-heading

--- a/release-notes/release-notes-galera-25.3.29.txt
+++ b/release-notes/release-notes-galera-25.3.29.txt
@@ -1,0 +1,89 @@
+Codership is pleased to announce the release of Galera Replication library 3.29,
+implementing wsrep API version 25.
+
+The library is now available as targeted packages and package repositories
+for a number of Linux distributions, including Ubuntu, Debian, CentOS,
+RHEL, OpenSUSE and SLES. Obtaining packages using a package repository
+removes the need to download individual files and facilitates the deployment
+and upgrade of Galera nodes.
+
+This and future releases will be available from https://www.galeracluster.com.
+
+The latest version of Galera for FreeBSD is available in the FreeBSD
+Ports Collection.
+
+
+Notable fixes in Galera replication since last binary release
+by Codership (3.28):
+
+* A bug in GCS where JOIN message was delivered even if the node
+  was in DONOR state was fixed.
+
+* An issue where GCache could contain mixed histories from different
+  clusters was fixed.
+
+* Setting socket.recv_buf_size was not effective because it was done
+  after the socket was connected or accepted. Also the default value
+  caused TCP receive buffer autotuning to be disabled. This lead to
+  suboptimal performance in high bandwidth WAN clusters.
+
+  The default value for socket.recv_buf_size was changed to 'auto'
+  which lets the kernel to tune TCP receive buffer. A new variable
+  socket.send_buf_size with default value 'auto' was added to allow
+  also send buffer tuning.
+  (codership/galera#552)
+
+* GComm socket timestamping/liveness checking caused false positives
+  during replication of large transactions, which caused excessive amounts
+  of broken connections. (codership/galera#553)
+
+* Large transactions were able to monopolize bandwidth when segmentation
+  was configured. This caused messages which were relayed by segment
+  representative to be delayed. As a fix implemented fair queuing of
+  messages. (codership/galera#553)
+
+* GComm EVS layer did excessive broadcasting to retransmit missing messages
+  when packets were lost or delayed. The communication protocol was optimized
+  to use point-to-point messaging to deliver missing messages and to rate
+  limit retransmission requests. (codership/galera#554)
+
+* Because of a bug in quorum computation, two primary conflicting primary
+  components were formed when the group merged and partitioned again
+  while the new primary view was forming.
+  (codership/galera#563)
+
+Reminder: Changes to Repositories Structure
+===========================================
+
+With the new release the repository structure is changed
+to allow for existence of all of the wsrep-patched mysql
+versions currently supported: 5.5 through 5.7.
+Thus the repository layout requires from the user to
+adjust his or her repository configuration to accomodate
+those changes. In order to have the WSREP and Galera
+library installed, one would need to add the following
+repositories:
+    1. Galera-3 repository for galera library:
+    e.g. https://releases.galeracluster.com/galera-3/<ldist>/
+    2. Corresponding mysql-wsrep repository:
+    e.g. https://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>
+    here: *ldist* is Linux distribution (Ubuntu, Centos, ...) and *mversion* is MySQL version, i.e.
+    5.5, 5.6, 5.7
+
+How To Install
+--------------
+
+Repositories contain dummy or meta packages, called mysql-wsrep-<mversion>
+which are convenience packages for installation of the corresponding version
+of WSREP. One can install the whole suite by running, for example:
+`apt-get install mysql-wsrep-5.6 galera-3`
+
+#### Quirks for Ubuntu Xenial and 5.6
+Due to the peculiarities of how apt resolves packages and presence of 5.7
+libraries in Xenial repositories the command above might require additional
+steps/changes in order to succeed.
+
+One would need to either configure apt pinning for codership repositories for
+them to have priority over upstream packages or to specify mysql-common package
+version explicitly as the one located in the WSREP repositories in order to get
+things installed.

--- a/release-notes/release-notes-mysql-wsrep-5.6.47-25.29.txt
+++ b/release-notes/release-notes-mysql-wsrep-5.6.47-25.29.txt
@@ -1,0 +1,65 @@
+Codership is pleased to announce a new release of Galera Cluster for MySQL
+consisting of MySQL-wsrep 5.6.47 and wsrep API version 25.
+
+This release incorporates all changes up to MySQL 5.6.47.
+
+Galera Cluster is now available as targeted packages and package repositories
+for a number of Linux distributions, including Ubuntu, Debian, CentOS,
+RHEL, OpenSUSE and SLES. Obtaining packages using a package repository
+removes the need to download individual files and facilitates the deployment and
+upgrade of Galera nodes.
+
+This and future releases will be available from https://www.galeracluster.com.
+
+The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD
+Ports Collection.
+
+The source repositories and bug tracking are now on
+https://github.com/codership/mysql-wsrep.
+
+
+Known issues with this release:
+
+* If using the Ubuntu 16.04 Xenial package, the server can not be bootstrapped
+  using systemd. Please use the SysV init script with the 'bootstap' option to
+  bootstrap the node. Note that a server that has been started that way can not
+  be controlled via systemd and must be stopped using the SysV script. Normal
+  server startup and shutdown is possible via systemd.
+
+* Server cannot be started using 'service' command on Debian Stretch.
+
+Reminder: Changes to Repositories Structure
+===========================================
+
+With the new release the repository structure is changed
+to allow for existence of all of the wsrep-patched mysql
+versions currently supported: 5.5 through 5.7.
+Thus the repository layout requires from the user to
+adjust his or her repository configuration to accomodate
+those changes. In order to have the WSREP and Galera
+library installed, one would need to add the following
+repositories:
+    1. Galera-3 repository for galera library:
+    e.g. https://releases.galeracluster.com/galera-3/<ldist>/
+    2. Corresponding mysql-wsrep repository:
+    e.g. https://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>
+    here: *ldist* is Linux or BSD distribution (Ubuntu, Centos) and *mversion* is MySQL version, i.e.
+    5.5, 5.6, 5.7
+
+How To Install
+--------------
+
+Repositories contain dummy or meta packages, called mysql-wsrep-<mversion>
+which are convenience packages for installation of the corresponding version
+of WSREP. One can install the whole suite by running, for example:
+`apt-get install mysql-wsrep-5.6 galera-3`
+
+#### Quirks for Ubuntu Xenial and 5.6
+Due to the peculiarities of how apt resolves packages and presence of 5.7
+libraries in Xenial repositories the command above might require additional
+steps/changes in order to succeed.
+
+One would need to either configure apt pinning for codership repositories for
+them to have priority over upstream packages or to specify mysql-common package
+version explicitly as the one located in the WSREP repositories in order to get
+things installed.

--- a/release-notes/release-notes-mysql-wsrep-5.7.29-25.21.txt
+++ b/release-notes/release-notes-mysql-wsrep-5.7.29-25.21.txt
@@ -1,0 +1,72 @@
+Codership is pleased to announce a new GA release of Galera Cluster for
+MySQL 5.7, consisting of MySQL-wsrep 5.7.29 and wsrep API version 25.
+
+This release incorporates all changes up to MySQL 5.7.29.
+
+Galera Cluster 5.7 is now available as targeted packages and package
+repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES.
+Obtaining packages using a package repository removes the need to download
+individual files and facilitates the deployment and upgrade of Galera nodes.
+
+This and future releases will be available from https://www.galeracluster.com.
+
+The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD
+Ports Collection.
+
+The source repositories and bug tracking are now on
+https://github.com/codership/mysql-wsrep.
+
+Notable fixes in MySQL-wsrep since the last binary release by Codership
+(5.7.28-25.20).
+
+* Fixed occasional hang during server shutdown. Due to race condition
+  a client connection got sometimes stuck in waiting for network event
+  from invalid file descriptor.
+
+Known issues with this release:
+
+* Server cannot be started using 'service' command on Debian Stretch.
+
+* SST between 5.6 and 5.7 nodes is not supported
+
+* InnoDB tablespaces outside of the data directory are not supported, as they
+  may not be copied over during SST
+
+* Compilation with DTrace enabled may fail, so -DENABLE_DTRACE=:BOOL=OFF
+  may be given to cmake to disable DTrace
+
+Changes to Repositories Structure
+=================================
+
+With the new release the repository structure is changed
+to allow for existence of all of the wsrep-patched mysql
+versions currently supported: 5.5 through 5.7.
+Thus the repository layout requires from the user to
+adjust his or her repository configuration to accomodate
+those changes. In order to have the WSREP and Galera
+library installed, one would need to add the following
+repositories:
+    1. Galera-3 repository for galera library:
+    e.g. https://releases.galeracluster.com/galera-3/<ldist>/
+    2. Corresponding mysql-wsrep repository:
+    e.g. https://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>
+    here: *ldist* is Linux or BSD distribution (Ubuntu, Centos) and *mversion* is MySQL version, i.e.
+    5.5, 5.6, 5.7
+
+How To Install
+--------------
+
+Repositories contain dummy or meta packages, called mysql-wsrep-<mversion>
+which are convenience packages for installation of the corresponding version
+of WSREP. One can install the whole suite by running, for example:
+`apt-get install mysql-wsrep-5.6 galera-3`
+
+#### Quirks for Ubuntu Xenial and 5.6
+Due to the peculiarities of how apt resolves packages and presence of 5.7
+libraries in Xenial repositories the command above might require additional
+steps/changes in order to succeed.
+
+One would need to either configure apt pinning for codership repositories for
+them to have priority over upstream packages or to specify mysql-common package
+version explicitly as the one located in the WSREP repositories in order to get
+things installed.


### PR DESCRIPTION
- Release notes
- Documented new Galera configuration option socket.send_buf_size and
  default change for socket.recv_buf_size.