### PR TITLE
Issue #428

### DIFF
--- a/galeracluster/source/documentation/mysql-wsrep-options.rst
+++ b/galeracluster/source/documentation/mysql-wsrep-options.rst
@@ -738,7 +738,7 @@ The node uses the format given by this parameter regardless of the client sessio
 
 This variable was introduced to support ``STATEMENT`` format replication during :term:`Rolling Schema Upgrade`.  In most cases, however, ``ROW`` format replication is valid for asymmetric schema replication.
 
-If you turn on ``wsrep_forced_binlog_format``, it is only effective for DML operations, to avoid binary log corruption. In addition, it is also deprecated, as ``binlog_format`` has been deprecated since MySQL 8.0.34. As the only possible logging format is ROW, this option is redundant.
+If you turn on ``wsrep_forced_binlog_format``, it is effective only for DML operations, to avoid any possible binlog corruption. In addition, since MySQL-wsrep 8.0.37-26.19, it is also deprecated, as ``binlog_format`` has been deprecated upstream since MySQL 8.0.34. As the only possible logging format is ROW, it makes this option redundant.
 
 You can execute the following ``SHOW VARIABLES`` statement with a ``LIKE`` operator to see how this variable is set:
 

--- a/galeracluster/source/documentation/mysql-wsrep-options.rst
+++ b/galeracluster/source/documentation/mysql-wsrep-options.rst
@@ -738,6 +738,8 @@ The node uses the format given by this parameter regardless of the client sessio
 
 This variable was introduced to support ``STATEMENT`` format replication during :term:`Rolling Schema Upgrade`.  In most cases, however, ``ROW`` format replication is valid for asymmetric schema replication.
 
+If you turn on ``wsrep_forced_binlog_format``, it is only effective for DML operations, to avoid binary log corruption. In addition, it is also deprecated, as ``binlog_format`` has been deprecated since MySQL 8.0.34. As the only possible logging format is ROW, this option is redundant.
+
 You can execute the following ``SHOW VARIABLES`` statement with a ``LIKE`` operator to see how this variable is set:
 
 .. code-block:: mysql


### PR DESCRIPTION
Added details on the wsrep_forced_binlog_format being effective for DML operations only. Also mentioned that binlog_format is deprecated.