### PR TITLE
s/wsrep_certs_index_size/wsrep_cert_index_size/g - thanks for the bug report

### DIFF
--- a/galeracluster/source/documentation/galera-status-variables.rst
+++ b/galeracluster/source/documentation/galera-status-variables.rst
@@ -308,12 +308,12 @@ To retrieve the value of this status variable, execute the ``SHOW STATUS`` state
 
 .. code-block:: mysql
 
-   SHOW STATUS LIKE 'wsrep_certs_index_size';
+   SHOW STATUS LIKE 'wsrep_cert_index_size';
 
    +------------------------+-------+
    | Variable_name          | Value |
    +------------------------+-------+
-   | wsrep_certs_index_size | 30936 |
+   | wsrep_cert_index_size | 30936 |
    +------------------------+-------+
 
 


### PR DESCRIPTION
fixed a long standing typo that was reported to us

commit 3aa145fed180f62aabe6995402f9e2b49886c8b4
Author: kennethpjdyer <kenneth@avoceteditors.com>
Date:   Sat Jan 10 22:19:15 2015 -0500

    Ref #38: Updates to Reference section.  Alphabetized table and reference entires.  Updated formatting on default/example column from italics to monospace.  Changed indexing for galerastatusvariables from 'parameters' to 'status variables'.